### PR TITLE
Add lambda={} prop example to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ const allGravityData = () => {
     return allGfForm
 }
 
-const examplePage = () => <GravityFormForm id={1} formData={allGravityData} />
+const examplePage = () => <GravityFormForm id={1} formData={allGravityData} lambda={process.env.LAMBDA_ENDPOINT} />
 export default examplePage
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -49,12 +49,12 @@ const GravityFormForm = ({ id, formData, lambda }) => {
             if (restResponse.status == 'error') {
                 // Handle the errors
                 // First check to make sure we have the correct data
-                if (doesObjectExist(res.data)) {
+                if (doesObjectExist(restResponse.data)) {
                     // Validation errors passed back by Gravity Forms
                     if (restResponse.data.status === 'gravityFormErrors') {
                         // Pass messages to handle that sets react-hook-form errors
                         handleGravityFormsValidationErrors(
-                            res.data.validation_messages,
+                            restResponse.data.validation_messages,
                             setError
                         )
                     }


### PR DESCRIPTION
Not sure if your component is supposed to pull this prop from somewhere else but it only seemed to work if I added it myself here.

```
<GravityFormForm
      id={formId}
      formData={data.allGfForm}
      lambda={process.env.LAMBDA_ENDPOINT}
    />
```