### PR TITLE
fix: CORS issue on OPTIONS requests

### DIFF
--- a/examples/newGfEntry.js
+++ b/examples/newGfEntry.js
@@ -25,7 +25,7 @@ exports.handler = async (event, context, callback) => {
     // Make sure we are dealing with a POST request
     if (event.httpMethod !== 'POST') {
         return {
-            statusCode: 400,
+            statusCode: 200, // <-- Important for CORS
             headers,
             body: JSON.stringify({
                 status: 'notPost',


### PR DESCRIPTION
Fixes issue when sending the OPTIONS request before the POST.
CORS now has no issues with the OPTIONS type when sending on non-localhost domains.

![Screen Shot 2019-10-11 at 09 01 22](https://user-images.githubusercontent.com/8282373/66639132-cbd16480-ec05-11e9-8c8f-72e20a9cb93b.png)
