### PR TITLE
Support for captcha field

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ const allGravityData = () => {
                                 size
                                 defaultValue
                                 maxLength
+                                # Optional, used only when you have a Captcha field on your Gravity Form
+                                captchaTheme
                             }
                             button {
                                 text
@@ -121,9 +123,21 @@ The data flow is as follows:
 3. Server takes post, and passes it to Gravity Forms as POST request
 4. Gravity Forms gets data
 
-Point 3 can be managed in multiple ways, depending on your build.
+Point 3 can be managed in multiple ways, depending on your build. For added security make sure you follow the steps below to implement reCAPTCHA on your form, preventing bots and spam.
 
-### Adding the Lambda (for Netlify)
+<details>
+
+<summary>Implementing Google reCAPTCHA</summary>
+
+On your Gatsby project (importing this module), set up an Environment Variable named `RECAPTCHA_SITE_KEY` with your reCAPTCHA site key as value. This variable will be automatically used whenever you render a Gravity Form that has a reCAPTCHA field.
+
+Upon responding to the captcha Google sends back a **reCAPTCHA response token** that gets stored in a hidden `<input>` on your form. When your form data is sent back to your Wordpress website(through a Lambda function), Gravity Forms will automatically [verify the reCAPTCHA token](https://developers.google.com/recaptcha/docs/verify) token to ensure it was sent by a human.
+
+</details>
+
+---
+
+## Adding the Lambda (for Netlify)
 
 If you are using Netlify then it is recommended you use a Lambda function. This process is _relatively_ plug and play.
 
@@ -220,8 +234,7 @@ If you are developing locally, you may run into an error "Cannot resolve React".
 -   [ ] Radio (half done, need to add default values)
 -   [x] Hidden
 -   [x] HTML
--   [ ] Captcha
-
+-   [x] Captcha
 -   [x] Add masking to inputs
 
 ### General Form

--- a/README.md
+++ b/README.md
@@ -122,19 +122,13 @@ The data flow is as follows:
 3. Server takes post, and passes it to Gravity Forms as POST request
 4. Gravity Forms gets data
 
-Point 3 can be managed in multiple ways, depending on your build. For added security make sure you follow the steps below to implement reCAPTCHA on your form, preventing bots and spam.
+Point 3 can be managed in multiple ways, depending on your build.
 
-<details>
+## Implementing Google reCAPTCHA
 
-<summary>Implementing Google reCAPTCHA</summary>
-
-On your Gatsby project (importing this module), set up an Environment Variable named `GATSBY_RECAPTCHA_SITE_KEY` with your reCAPTCHA site key as value. This variable will be automatically used whenever you render a Gravity Form that has a reCAPTCHA field.
+On your Gatsby project set up an Environment Variable named `GATSBY_RECAPTCHA_SITE_KEY` with your reCAPTCHA site key as value. This variable will be automatically used whenever Gravity Form that has a reCAPTCHA field.
 
 Upon responding to the captcha Google sends back a **reCAPTCHA response token** that gets stored in a hidden `<input>` on your form. When your form data is sent back to your Wordpress website(through a Lambda function), Gravity Forms will automatically [verify the reCAPTCHA token](https://developers.google.com/recaptcha/docs/verify) token to ensure it was sent by a human.
-
-</details>
-
----
 
 ## Adding the Lambda (for Netlify)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gatsby-gravityforms-component",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "description": "A component to take gatsby-source-gravityforms query data and return usable components",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "prop-types": "^15.7.2",
         "react-hook-form": "^3.14.0",
         "react-html-parser": "^2.0.2",
+        "reaptcha": "^1.7.2",
         "sanitize-html": "^1.20.1"
     },
     "devDependencies": {
@@ -66,7 +67,6 @@
         "webpack-cli": "^3.2.0"
     },
     "peerDependencies": {
-        "react": "^16.8.6",
         "react-dom": "^16.8.6"
     }
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
         "webpack-cli": "^3.2.0"
     },
     "peerDependencies": {
+        "react": "^16.8.6",
         "react-dom": "^16.8.6"
     }
 }

--- a/src/components/Captcha/index.js
+++ b/src/components/Captcha/index.js
@@ -1,8 +1,14 @@
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import Reaptcha from 'reaptcha'
 
-const Captcha = ({ captchaTheme, register, setValue }) => {
+const Captcha = ({
+    captchaTheme,
+    errors,
+    register,
+    setValue,
+    wrapClassName,
+}) => {
     if (!process.env.RECAPTCHA_SITE_KEY) {
         return (
             <p>
@@ -18,15 +24,27 @@ const Captcha = ({ captchaTheme, register, setValue }) => {
         )
     }
 
+    const captchaRef = useRef(null)
+    const [isLoaded, setLoaded] = useState(false)
+
     const changeCaptchaToken = (token = '') => {
         setValue('g-recaptcha-response', token, true)
     }
 
+    useEffect(() => {
+        if (isLoaded && errors && errors.message) {
+            console.log('resetting')
+            captchaRef.current.reset()
+        }
+    }, [errors, isLoaded])
+
     return (
-        <>
+        <div className={wrapClassName}>
             <Reaptcha
                 onExpire={changeCaptchaToken}
+                onLoad={() => setLoaded(true)}
                 onVerify={changeCaptchaToken}
+                ref={captchaRef}
                 sitekey={process.env.RECAPTCHA_SITE_KEY}
                 theme={captchaTheme || 'light'}
             />
@@ -35,14 +53,21 @@ const Captcha = ({ captchaTheme, register, setValue }) => {
                 ref={register({})}
                 type="hidden"
             />
-        </>
+            {errors && (
+                <div className="gravityform__error_message">
+                    {errors.message}
+                </div>
+            )}
+        </div>
     )
 }
 
 Captcha.propTypes = {
     captchaTheme: PropTypes.string,
+    errors: PropTypes.object,
     register: PropTypes.func,
     setValue: PropTypes.func,
+    wrapClassName: PropTypes.string,
 }
 
 export default Captcha

--- a/src/components/Captcha/index.js
+++ b/src/components/Captcha/index.js
@@ -33,7 +33,6 @@ const Captcha = ({
 
     useEffect(() => {
         if (isLoaded && errors && errors.message) {
-            console.log('resetting')
             captchaRef.current.reset()
         }
     }, [errors, isLoaded])

--- a/src/components/Captcha/index.js
+++ b/src/components/Captcha/index.js
@@ -28,7 +28,7 @@ const Captcha = ({ captchaTheme, register, setValue }) => {
                 onExpire={changeCaptchaToken}
                 onVerify={changeCaptchaToken}
                 sitekey={process.env.RECAPTCHA_SITE_KEY}
-                theme={captchaTheme}
+                theme={captchaTheme || 'light'}
             />
             <input
                 name="g-recaptcha-response"

--- a/src/components/Captcha/index.js
+++ b/src/components/Captcha/index.js
@@ -1,0 +1,48 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import Reaptcha from 'reaptcha'
+
+const Captcha = ({ captchaTheme, register, setValue }) => {
+    if (!process.env.RECAPTCHA_SITE_KEY) {
+        return (
+            <p>
+                <strong>
+                    To use reCAPTCHA, you need to sign up for an API key pair
+                    for your site and use it as a node environment variable
+                    named RECAPTCHA_SITE_KEY. The key pair consists of a site
+                    key and secret. The site key is used to display the widget
+                    on your site. Sign up for an API key pair at
+                    http://www.google.com/recaptcha.
+                </strong>
+            </p>
+        )
+    }
+
+    const changeCaptchaToken = (token = '') => {
+        setValue('g-recaptcha-response', token, true)
+    }
+
+    return (
+        <>
+            <Reaptcha
+                onExpire={changeCaptchaToken}
+                onVerify={changeCaptchaToken}
+                sitekey={process.env.RECAPTCHA_SITE_KEY}
+                theme={captchaTheme}
+            />
+            <input
+                name="g-recaptcha-response"
+                ref={register({})}
+                type="hidden"
+            />
+        </>
+    )
+}
+
+Captcha.propTypes = {
+    captchaTheme: PropTypes.string,
+    register: PropTypes.func,
+    setValue: PropTypes.func,
+}
+
+export default Captcha

--- a/src/components/Captcha/index.js
+++ b/src/components/Captcha/index.js
@@ -11,16 +11,25 @@ const Captcha = ({
 }) => {
     if (!process.env.GATSBY_RECAPTCHA_SITE_KEY) {
         return (
-            <p>
-                <strong>
-                    To use reCAPTCHA, you need to sign up for an API key pair
-                    for your site and use it as a node environment variable
-                    named GATSBY_RECAPTCHA_SITE_KEY. The key pair consists of a site
-                    key and secret. The site key is used to display the widget
-                    on your site. Sign up for an API key pair at
-                    http://www.google.com/recaptcha.
-                </strong>
-            </p>
+            <div className="gravityform__captcha_notification">
+                <p>
+                    <strong>
+                        To use reCAPTCHA, you need to sign up for an API key
+                        pair for your site and use it as a node environment
+                        variable named GATSBY_RECAPTCHA_SITE_KEY. The key pair
+                        consists of a site key and secret. The site key is used
+                        to display the widget on your site. Sign up for an API
+                        key pair at 
+                        <a
+                            target="_blank"
+                            title="This link opens a new page"
+                            href="http://www.google.com/recaptcha"
+                        >
+                            http://www.google.com/recaptcha
+                        </a>
+                    </strong>
+                </p>
+            </div>
         )
     }
 

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -42,7 +42,7 @@ const Input = ({
                 )}
                 defaultValue={value}
                 id={name}
-                maxLength={maxLength > 0 ? maxLength : undefined}
+                maxLength={maxLength} // 524288 = 512kb, avoids invalid prop type error if maxLength is undefined.
                 name={name}
                 placeholder={placeholder}
                 ref={register({
@@ -84,7 +84,7 @@ Input.propTypes = {
     errors: PropTypes.object,
     inputMaskValue: PropTypes.string,
     label: PropTypes.string,
-    maxLength: PropTypes.int,
+    maxLength: PropTypes.number,
     name: PropTypes.string,
     placeholder: PropTypes.string,
     register: PropTypes.func,

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -42,7 +42,7 @@ const Input = ({
                 )}
                 defaultValue={value}
                 id={name}
-                maxLength={maxLength} // 524288 = 512kb, avoids invalid prop type error if maxLength is undefined.
+                maxLength={maxLength || 524288} // 524288 = 512kb, avoids invalid prop type error if maxLength is undefined.
                 name={name}
                 placeholder={placeholder}
                 ref={register({

--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -79,7 +79,7 @@ Textarea.propTypes = {
     errors: PropTypes.obj,
     inputMaskValue: PropTypes.string,
     label: PropTypes.string,
-    maxLength: PropTypes.string,
+    maxLength: PropTypes.number,
     name: PropTypes.string,
     placeholder: PropTypes.string,
     register: PropTypes.func,

--- a/src/container/FieldBuilder/index.js
+++ b/src/container/FieldBuilder/index.js
@@ -18,11 +18,11 @@ import {
 } from '../../utils/inputSettings'
 
 const FieldBuilder = ({
+    errors,
     formData,
     presetValues = {},
-    setValue,
     register,
-    errors,
+    setValue,
 }) => {
     // The top level settings for the whole form
     const formSettings = {
@@ -49,9 +49,11 @@ const FieldBuilder = ({
                 return (
                     <Captcha
                         captchaTheme={field.captchaTheme}
+                        errors={errors[`input_${field.id}`]}
                         key={field.id}
                         register={register}
                         setValue={setValue}
+                        wrapClassName={inputWrapperClass}
                     />
                 )
             // Start with the standard fields
@@ -101,7 +103,7 @@ const FieldBuilder = ({
                         inputMaskValue={field.inputMaskValue}
                         key={field.id}
                         label={field.label}
-                        maxLength={field.maxLength || 52428} // 524288 = 512kb, avoids invalid prop type error if maxLength is undefined.
+                        maxLength={field.maxLength}
                         name={`input_${field.id}`}
                         placeholder={field.placeholder}
                         register={register}

--- a/src/container/FieldBuilder/index.js
+++ b/src/container/FieldBuilder/index.js
@@ -2,6 +2,7 @@ import classnames from 'classnames'
 import _ from 'lodash'
 import React from 'react'
 
+import Captcha from '../../components/Captcha'
 import Checkbox from '../../components/Checkbox'
 import Html from '../../components/Html'
 import Input from '../../components/Input'
@@ -16,7 +17,13 @@ import {
     islabelHidden,
 } from '../../utils/inputSettings'
 
-const FieldBuilder = ({ formData, presetValues = {}, register, errors }) => {
+const FieldBuilder = ({
+    formData,
+    presetValues = {},
+    setValue,
+    register,
+    errors,
+}) => {
     // The top level settings for the whole form
     const formSettings = {
         descriptionPlacement: formData.descriptionPlacement,
@@ -40,14 +47,12 @@ const FieldBuilder = ({ formData, presetValues = {}, register, errors }) => {
             // Add note for unsupported captcha field
             case 'captcha':
                 return (
-                    <p>
-                        <strong>
-                            Gatsby Gravity Form Component currently does not
-                            support the CAPTCHA field. Form will not submit with
-                            this field present. Remove this field from the
-                            Gravity Form.
-                        </strong>
-                    </p>
+                    <Captcha
+                        captchaTheme={field.captchaTheme}
+                        key={field.id}
+                        register={register}
+                        setValue={setValue}
+                    />
                 )
             // Start with the standard fields
             case 'text':
@@ -96,7 +101,7 @@ const FieldBuilder = ({ formData, presetValues = {}, register, errors }) => {
                         inputMaskValue={field.inputMaskValue}
                         key={field.id}
                         label={field.label}
-                        maxLength={field.maxLength}
+                        maxLength={field.maxLength || 52428} // 524288 = 512kb, avoids invalid prop type error if maxLength is undefined.
                         name={`input_${field.id}`}
                         placeholder={field.placeholder}
                         register={register}

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ import passToGravityForms from './utils/passToGravityForms'
 
 const GravityFormForm = ({ id, formData, lambda, presetValues = {} }) => {
     // Pull in form functions
-    const { errors, handleSubmit, register, setError } = useForm()
+    const { errors, handleSubmit, register, setError, setValue } = useForm()
 
     const [generalError, setGeneralError] = useState('')
     const [formLoading, setLoadingState] = useState(false)
@@ -106,6 +106,7 @@ const GravityFormForm = ({ id, formData, lambda, presetValues = {} }) => {
                         formId={id}
                         presetValues={presetValues}
                         register={register}
+                        setValue={setValue}
                     />
                     <button className="gravityform__button" type="submit">
                         {singleForm.button.text

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ import ReactHtmlParser from 'react-html-parser'
 import FormGeneralError from './components/FormGeneralError'
 import FieldBuilder from './container/FieldBuilder'
 import getForm from './utils/getForm'
-import { doesObjectExist } from './utils/helpers'
 import {
     handleGravityFormsValidationErrors,
     // manageMainFormError,
@@ -38,13 +37,13 @@ const GravityFormForm = ({ id, formData, lambda, presetValues = {} }) => {
     const onSubmitCallback = async values => {
         // Make sure we are not already waiting for a response
         if (!formLoading) {
-            setLoadingState(true)
-
             // Clean error
             setGeneralError('')
 
             // Check that at least one field has been filled in
             if (submissionHasOneFieldEntry(values)) {
+                setLoadingState(true)
+
                 const restResponse = await passToGravityForms(
                     singleForm.apiURL,
                     values,
@@ -56,17 +55,18 @@ const GravityFormForm = ({ id, formData, lambda, presetValues = {} }) => {
                 if (restResponse.status === 'error') {
                     // Handle the errors
                     // First check to make sure we have the correct data
-                    if (doesObjectExist(restResponse.data)) {
+                    if (restResponse.data) {
                         // Validation errors passed back by Gravity Forms
-                        if (restResponse.data.status === 'gravityFormErrors') {
+                        const { data } = restResponse.data
+
+                        if (data.status === 'gravityFormErrors') {
                             // Pass messages to handle that sets react-hook-form errors
                             handleGravityFormsValidationErrors(
-                                restResponse.data.validation_messages,
+                                data.validation_messages,
                                 setError
                             )
                         }
                     } else {
-                        console.log(restResponse)
                         // Seemed to be an unknown issue
                         setGeneralError('unknownError')
                     }


### PR DESCRIPTION
This PR adds minimal support for the Recaptcha field available on Gravity Forms. As of now the only customisation available is the captcha theme (field `captchaTheme` available on the `allGfForm` GraphQL node). 

The recaptcha site key needs to be provided in the form of an environment variable named `RECAPTCHA_SITE_KEY`. When unavailable the Captcha field component displays an error outlining how to get a Recaptcha Site Key.

Let me know if I messed up the code structure or need to improve upon anything else. Thanks!