### PR TITLE
Fix 'TypeError: nanoid is not a function' error in newGfEntry.js

### DIFF
--- a/examples/newGfEntry.js
+++ b/examples/newGfEntry.js
@@ -1,5 +1,5 @@
 const axios = require('axios')
-const nanoid = require('nanoid')
+const { nanoid } = require('nanoid')
 const oauthSignature = require('oauth-signature')
 
 let activeEnv =


### PR DESCRIPTION
`nanoid` is a function inside of the module itself, therefor it will throw an error once it's minified by Netlify and throw a 502 error in production.